### PR TITLE
Infer key on model's $build method

### DIFF
--- a/src/module/restmod.js
+++ b/src/module/restmod.js
@@ -214,8 +214,16 @@ angular.module('plRestmod')
             $url: function() {
               return urlBuilder.collectionUrl(this);
             },
-            $build: function(_attr) {
-              var obj = new Model(_attr, null, this);
+            $build: function(_key) {
+              var init, keyName;
+              if(!isObject(_key)) {
+                init = {};
+                keyName = urlBuilder.inferKey(this);
+                if(!keyName) throw $restmodMinErr('notsup', 'Cannot infer build key, use explicit mode');
+                init[keyName] = _key;
+              } else init = _key;
+
+              var obj = new Model(init, null, this);
               if(this.$isCollection) this.push(obj); // on collection, push new object
               return obj;
             },

--- a/test/modelSpec.js
+++ b/test/modelSpec.js
@@ -44,6 +44,10 @@ describe('Restmod model class:', function() {
       expect(book.name).toEqual('Los piratas del Caribe');
     });
 
+    it('should infer the key when not used an explicit one', function(){
+      var book = Book.$build(1);
+      expect(book.id).toEqual(1);
+    });
   });
 
   describe('$create', function() {


### PR DESCRIPTION
Be able just pass an id as a parameter for a `$build` method

``` js
Book.$build(1);
```

I tried to came up with a way that not duplicate all the code taken from the `$find` method, but I couldn't determine if that duplication was ok, or should be separated on another method...
