### PR TITLE
feat(CacheModel): add a CacheModel mixin

### DIFF
--- a/src/plugins/cache.js
+++ b/src/plugins/cache.js
@@ -1,0 +1,67 @@
+'use strict';
+
+angular.module('restmod').factory('CacheModel', ['restmod',
+    function (restmod) {
+        var mixin = restmod.mixin(function () {
+
+            var cache = {};
+
+            //
+            // Listeners
+            // ------------------------------------------------------------
+            this.on('after-fetch-many', function (xhr) {
+                cache[this.$url()] = this;
+                angular.forEach(this, function (record) {
+                    cache[record.$url()] = record;
+                });
+            });
+
+            this.on('after-fetch', function (xhr) {
+                cache[this.$url()] = this;
+            });
+
+            this.on('after-save', function (xhr) {
+                cache[this.$url()] = this;
+            });
+
+            this.on('after-destroy', function (xhr) {
+                delete cache[this.$url()];
+            });
+
+            //
+            // Cache overrides
+            // ------------------------------------------------------------
+            this.classDefine('$fetch', function () {
+                var cached = cache[this.$url()];
+                if (cached) {
+                    return cached;
+                } else {
+                    this.$super.apply(this, arguments);
+                    cache[this.$url()] = this;
+                    return this;
+                }
+            });
+
+            this.classDefine('$find', function (_pk) {
+                var cached = cache[this.$urlFor(_pk)];
+                if (cached) {
+                    return cached;
+                } else {
+                    var record = this.$super.apply(this, arguments);
+                    cache[record.$url()] = record;
+                    return record;
+                }
+            });
+
+            this.classDefine('$eject', function () {
+                angular.forEach(Object.keys(cache), function(key) {
+                    delete cache[key];
+                });
+            });
+            // set a pointer for cache
+            this.classDefine('$cache', cache);
+        });
+
+        return mixin;
+    }
+]);

--- a/test/plugins/cache-spec.js
+++ b/test/plugins/cache-spec.js
@@ -1,0 +1,132 @@
+'use strict';
+
+describe('Plugin: Cache Model', function () {
+
+    beforeEach(module('restmod'));
+
+    beforeEach(module(function ($provide, restmodProvider) {
+        restmodProvider.pushModelBase('CacheModel');
+        $provide.factory('Bike', function (restmod) {
+            return restmod.model('/api/bikes');
+        });
+    }));
+
+    describe('$search', function () {
+        var bikesResponse = [{}, {}];
+        beforeEach(inject(function ($httpBackend) {
+            $httpBackend.expectGET('/api/bikes').respond(200, bikesResponse);
+
+        }));
+
+        it('should generate only one request when called consecutivelly', inject(function ($httpBackend, Bike) {
+            var bikes = Bike.$collection();
+            bikes.$fetch();
+            bikes.$fetch();
+            $httpBackend.flush();
+        }));
+
+        it('should return cached collection on second call', inject(function ($httpBackend, Bike) {
+            var bikes1 = Bike.$search();
+            $httpBackend.flush();
+            var bikes2 = Bike.$search();
+            expect(bikes1).toEqual(bikes2);
+        }));
+
+        it('should clear cache on eject', inject(function ($httpBackend, Bike) {
+            Bike.$search();
+            $httpBackend.flush();
+            Bike.$eject();
+            expect(Bike.$cache).toEqual({});
+        }));
+
+        it('should not return cached collection after eject', inject(function ($httpBackend, Bike) {
+            var bikes1 = Bike.$search();
+            $httpBackend.flush();
+            Bike.$eject();
+            var bikes2 = Bike.$search();
+            $httpBackend.expectGET('/api/bikes').respond(200, bikesResponse);
+            $httpBackend.flush();
+            expect(bikes1).not.toEqual(bikes2);
+        }));
+    });
+
+    describe('$find', function () {
+        var bikesResponse = {
+            id: 1
+        };
+
+        it('should generate only one request when called consecutivelly', inject(function ($httpBackend, Bike) {
+            $httpBackend.expectGET('/api/bikes/1').respond(200, bikesResponse);
+            Bike.$find(1);
+            Bike.$find(1);
+            $httpBackend.flush();
+        }));
+
+        it('should return cached record on second call', inject(function ($httpBackend, Bike) {
+            $httpBackend.expectGET('/api/bikes/1').respond(200, bikesResponse);
+            var bike1 = Bike.$find(1);
+            $httpBackend.flush();
+            var bike2 = Bike.$find(1);
+            expect(bike1).toEqual(bike2);
+        }));
+
+        it('should return cached record from a $search', inject(function ($httpBackend, Bike) {
+            $httpBackend.expectGET('/api/bikes').respond(200, [bikesResponse]);
+            Bike.$search();
+            $httpBackend.flush();
+            var bike = Bike.$find(1);
+            expect(bike.$pk).toEqual(1);
+        }));
+    });
+
+    describe('$save', function () {
+        it('should cache a saved record', inject(function ($httpBackend, $timeout, Bike) {
+            $httpBackend.expectPOST('/api/bikes').respond(200, {
+                id: 2
+            });
+            var spy = jasmine.createSpy();
+            Bike.$create({
+                id: 2
+            });
+            $httpBackend.flush();
+            Bike.$find(2).$then(spy);
+            $timeout.flush();
+            expect(spy).toHaveBeenCalled();
+        }));
+    });
+
+    describe('$destroy', function () {
+        var bike;
+        beforeEach(inject(function($httpBackend, Bike) {
+            //Cache record
+            $httpBackend.expectGET('/api/bikes/1').respond(200, {
+                id: 1
+            });
+            bike = Bike.$find(1);
+            $httpBackend.flush();
+            expect(Bike.$cache[bike.$url()]).toBeDefined();
+        }));
+
+        it('should remove destroyed record from cache', inject(function ($httpBackend, Bike) {
+            //Destroy record
+            $httpBackend.expectDELETE('/api/bikes/1').respond(200);
+            bike.$destroy();
+            $httpBackend.flush();
+            expect(Bike.$cache[bike.$url()]).toBeUndefined();
+        }));
+
+        it('should remove destroyed record from collections', inject(function ($httpBackend, Bike) {
+            $httpBackend.expectGET('/api/bikes').respond(200, [{id:1}, {id:2}]);
+            Bike.$search();
+            $httpBackend.flush();
+            //Destroy record
+            $httpBackend.expectDELETE('/api/bikes/1').respond(200);
+            bike.$destroy();
+            $httpBackend.flush();
+            var bikes = Bike.$search();
+            angular.forEach(bikes, function(record) {
+                if(record.id === bike.id) throw Error('Record not removed from collection');
+            });
+        }));
+    });
+});


### PR DESCRIPTION
My attempt at a cache model mixin based on the discussions in #27.
Thoughts?

I haven't quite figured out a good way to get the last test to pass `should remove destroyed record from collections`, without looking through all the items in the cache and everything cached for each of those items. 
