### PR TITLE
Fix AMS Style to use propper setPacker function arguments.

### DIFF
--- a/src/styles/ams.js
+++ b/src/styles/ams.js
@@ -13,7 +13,7 @@ angular.module('restmod').factory('AMSApi', ['restmod', 'inflector', 'DefaultPac
 		this.setProperty('style', 'AMS')
 			.setProperty('primaryKey', 'id') // just to make sure
 			.setRenamer(amsRenamer)
-			.setPacker('packer', DefaultPacker)
+			.setPacker(DefaultPacker)
 			.setProperty('jsonMeta', 'meta')
 			.setProperty('jsonLinks', 'links');
 	});


### PR DESCRIPTION
The `setPacker` method takes only one argument. This argument is either the packer object, or a string with the name of the factory to be instantiated. The AMS style used two arguments - `'packer'` and `DefaultPacker`, which caused restmod to try to instantiate the "packerPacker" factory, throwing a Unknown provider exception.
