### PR TITLE
featu(computed): Add computed property

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -12,7 +12,7 @@ var RMModule = angular.module('restmod', ['ng', 'platanus.inflector']);
  */
 RMModule.provider('restmod', [function() {
 
-  var BASE_CHAIN = ['RMBuilderExt', 'RMBuilderRelations'];
+  var BASE_CHAIN = ['RMBuilderExt', 'RMBuilderRelations', 'RMBuilderComputed'];
 
   function wrapInInvoke(_mixin) {
     return function(_injector) {

--- a/src/module/extended/builder-computed.js
+++ b/src/module/extended/builder-computed.js
@@ -1,0 +1,41 @@
+'use strict';
+
+RMModule.factory('RMBuilderComputed', ['restmod',
+  function(restmod) {
+    /**
+     * @class RMBuilderComputedApi
+     *
+     * @description
+     *
+     * Builder DSL extension to build computed properties.
+     *
+     * A computed property is a "virtual" property which is created using
+     * other model properties. For example, a user has a firstName and lastName,
+     * A computed property, fullName, is generated from the two.
+     *
+     * Adds the following property modifiers:
+     * * `computed` function will be assigned as getter to Model, maps to {@link RMBuilderComputedApi#attrAsComputed}
+     *
+     */
+    var EXT = {
+
+      /**
+       * @memberof RMBuilderComputedApi#
+       *
+       * @description Registers a model computed property
+       *
+       * @param {string}  _attr Attribute name
+       * @param {function} _fn Function that returns the desired attribute value when run. 
+       * @return {BuilderApi} self
+       */
+      attrAsComputed: function(_attr, _fn) {
+        this.attrComputed(_attr, _fn);
+        return this;
+      }
+    }
+
+    return restmod.mixin(function() {
+      this.extend('attrAsComputed', EXT.attrAsComputed, ['computed']);
+    });
+  }
+]);

--- a/src/module/factory.js
+++ b/src/module/factory.js
@@ -24,6 +24,7 @@ RMModule.factory('RMModelFactory', ['$injector', 'inflector', 'RMUtils', 'RMScop
         urlPrefix: null
       },
       serializer = new Serializer(Model),
+      computes = {},
       defaults = [],                    // attribute defaults as an array of [key, value]
       meta = {},                        // atribute metadata
       hooks = {},
@@ -331,10 +332,19 @@ RMModule.factory('RMModelFactory', ['$injector', 'inflector', 'RMUtils', 'RMScop
 
       // default initializer: loads the default parameter values
       $initialize: function() {
-        var tmp;
+        var tmp, self = this;
         for(var i = 0; (tmp = defaults[i]); i++) {
           this[tmp[0]] = (typeof tmp[1] === 'function') ? tmp[1].apply(this) : tmp[1];
         }
+        Object.keys(computes).forEach(function(key) {
+          //console.log(self);
+          Object.defineProperty(self, key, {
+            enumerable: true,
+            get: function() {
+              return computes[key].apply(self);
+            }
+          });
+        });
       }
 
     }, CommonApi, RecordApi, ExtendedApi);
@@ -430,6 +440,22 @@ RMModule.factory('RMModelFactory', ['$injector', 'inflector', 'RMUtils', 'RMScop
        */
       attrDefault: function(_attr, _init) {
         defaults.push([_attr, _init]);
+        return this;
+      },
+
+      /**
+       * @memberof BuilderApi#
+       *
+       * @description Sets a computed value for an attribute.
+       *
+       * Computed values are set only on object construction phase.
+       *
+       * @param {string} _attr Attribute name
+       * @param {function} _fn Function that returns value
+       * @return {BuilderApi} self
+       */
+      attrComputed: function(_attr, _fn) {
+        computes[_attr] = _fn;
         return this;
       },
 

--- a/test/computed-spec.js
+++ b/test/computed-spec.js
@@ -1,0 +1,94 @@
+'use strict';
+
+describe('RMBuilderComputed', function() {
+
+  var $injector, restmod, RMBuilderComputed, UserModel;
+
+  beforeEach(module('restmod'));
+
+  beforeEach(module(function($provide, restmodProvider) {
+    $provide.factory('UserModel', function(restmod) {
+      return restmod.model('/api/users', {
+        firstName: ''
+      });
+    });
+  }));
+
+
+  // cache entities to be used in tests
+  beforeEach(inject(['$injector',
+    function(_$injector) {
+      $injector = _$injector;
+      restmod = $injector.get('restmod');
+      RMBuilderComputed = $injector.get('RMBuilderComputed');
+      UserModel = restmod.model('/api/users', {
+        firstName: ''
+      });
+    }
+  ]));
+
+  describe('computed property', function() {
+
+    describe('basics', function() {
+
+      var DeviceModel, device;
+      beforeEach(function() {
+        DeviceModel = restmod.model('/api/devices', {
+          vendor: 'default vendor',
+          model: 'default model',
+          fancyName: {
+            computed: function() {
+              return this.vendor + ': ' + this.model;
+            }
+          }
+        });
+        device = DeviceModel.$new().$decode();
+      });
+
+      it('calculates using given function', function() {
+        expect(device.fancyName).toEqual('default vendor: default model');
+      });
+
+      it('changes when model properties update', function() {
+        device.vendor = "Apple";
+        device.model = "iPhone";
+        expect(device.fancyName).toEqual('Apple: iPhone');
+      });
+
+    });
+
+    describe('with relations', function() {
+
+      var DeviceModel, UserModel, device;
+      beforeEach(function() {
+
+        DeviceModel = restmod.model('/api/devices', {
+          vendor: '',
+          model: '',
+          user: {
+            hasOne: 'UserModel'
+          },
+          ownedBy: {
+            computed: function() {
+              return this.user.firstName + "'s " + this.model;
+            }
+          }
+        });
+        device = DeviceModel.$new().$decode({
+          vendor: 'Apple',
+          model: 'Watch',
+          user: {
+            firstName: 'Johnny'
+          }
+        });
+      });
+
+      it('can access related models', function() {
+        expect(device.ownedBy).toEqual("Johnny's Watch");
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
This PR adds support for computed properties. 

It addresses https://github.com/platanus/angular-restmod/issues/85

Todo: 
- How is masking handled? - In most (all?) cases these properties should not be sent to the API. Does the user need to define the mask, or should we add the mask automatically? 
- The performance of these computed properties is not optimized since there is no watching. The function is run every time the property is accessed. This will only be noticeable in huge quantities.
