### PR TITLE
Descendant property

### DIFF
--- a/src/module/support/default-packer.js
+++ b/src/module/support/default-packer.js
@@ -29,6 +29,10 @@ RMModule.factory('DefaultPacker', ['restmod', 'inflector', 'RMPackerCache', func
     }
   }
 
+  function getDescendantProperty(_object, _key) {
+    return _key ? _object[_key] : _object;
+  }
+
   /**
    * @class DefaultPacker
    *
@@ -118,7 +122,7 @@ RMModule.factory('DefaultPacker', ['restmod', 'inflector', 'RMPackerCache', func
         });
       }
 
-      return _raw[name];
+      return name.split('.').reduce(getDescendantProperty, _raw);
     });
   });
 

--- a/test/default-packer-spec.js
+++ b/test/default-packer-spec.js
@@ -62,6 +62,20 @@ describe('DefaultPacker', function() {
       expect(many[0].model).toEqual('Slash');
     });
 
+    it('should get the descendant property in a nested json object', function() {
+      var model = restmod.model('/api/bikes').mix('DefaultPacker', {
+        $config: { jsonRoot: 'parent.child.the_root' }
+      });
+
+      var record = model.$new(1);
+      record.$unwrap({parent: { child: { the_root: { model: 'Slash' } } } });
+      expect(record.model).toEqual('Slash');
+
+      var many = model.$collection();
+      many.$unwrap({parent: { child: { the_root: [{ model: 'Slash' }] } } });
+      expect(many[0].model).toEqual('Slash');
+    });
+
   });
 
   describe('processMeta', function() {


### PR DESCRIPTION
Fixes an issue where the `jsonRoot` would only reach top level properties instead of descendant properties in a nested json object and you don't want to create relationships:

```javascript
{
  "parent": {
    "child": {
      "the_root": {
        ...
      }
    }
  }
}
```

Fixed by adding a dot notated string to either the `jsonRoot`, `jsonRootSingle` or `jsonRootMany`.
```javascript
$config: {
  jsonRoot: 'parent.child.the_root'
}
```