### PR TITLE
Fixed error when use NestedDirtyModel plugin to $restore() a computed properties

### DIFF
--- a/src/module/factory.js
+++ b/src/module/factory.js
@@ -375,7 +375,8 @@ RMModule.factory('RMModelFactory', ['$injector', '$log', 'inflector', 'RMUtils',
         for(i = 0; (tmp = computes[i]); i++) {
           Object.defineProperty(self, tmp[0], {
             enumerable: true,
-            get: tmp[1]
+            get: tmp[1],
+            set: function() {}
           });
         }
       }


### PR DESCRIPTION
When $restore() function of NestedDirtyModel plugin is used to restore a record which has computed properties, the application is crashed and the error occurs.

```
Cannot set property 'computed_properties' of #<r> which has only a getter
```