### PR TITLE
package.json main file need to be the bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "git://github.com/angular-platanus/restmod.git"
   },
-  "main": "dist/angular-restmod.js",
+  "main": "./dist/angular-restmod-bundle.js",
   "dependencies": {
     "angular": "*",
     "angular-inflector": "~0.2"


### PR DESCRIPTION
When browserify runs, use the bundle as the main files allows one to include all of the scripts.

Another solution is to add `require()` syntax to the scripts so that browserify can find it.