### PR TITLE
Give priority to restmod built-in mappings

### DIFF
--- a/src/module/builder.js
+++ b/src/module/builder.js
@@ -265,7 +265,9 @@ RMModule.factory('RMBuilder', ['$injector', 'inflector', '$log', 'RMUtils', func
       extend: function(_name, _fun, _mapping) {
         if(typeof _name === 'string') {
           this[_name] = Utils.override(this[name], _fun);
-          if(_mapping) mappings.push({ fun: _name, sign: _mapping });
+          if(_mapping) {
+            mappings.unshift({ fun: _name, sign: _mapping });
+          }
         } else Utils.extendOverriden(this, _name);
         return this;
       },


### PR DESCRIPTION
With the way mapping is set up currently, priority is given to the
builder extensions or user defined extensions to the dsl. This change
reverses this such that the built in restmod mappings like mask or
default take precedence over relations or user defined mappings.
