### PR TITLE
Enhancement: Almost all Http methods need to be configurable

### DIFF
--- a/src/module/api/record-api.js
+++ b/src/module/api/record-api.js
@@ -96,7 +96,7 @@ RMModule.factory('RMRecordApi', ['RMUtils', function(Utils) {
    * @property {mixed} $pk The record primary key
    * @property {object} $scope The collection scope (hierarchical scope, not angular scope)
    */
-	return {
+  return {
 
     /**
      * @memberof RecordApi#
@@ -271,6 +271,8 @@ RMModule.factory('RMRecordApi', ['RMUtils', function(Utils) {
      * @description Shortcut method used to extend and save a model.
      *
      * This method will not force a PUT, if object is new `$update` will attempt to POST.
+     * It is posible to change the methods used for PUT and POST operations by setting 
+     * the `putMethod` and `postMethod` configuration.
      *
      * @param {object} _other Data to change
      * @return {RecordApi} self
@@ -319,7 +321,11 @@ RMModule.factory('RMRecordApi', ['RMUtils', function(Utils) {
               })
             };
           } else {
-            request = { method: 'PUT', url: url, data: this.$wrap(Utils.UPDATE_MASK) };
+            request = { 
+              method: this.$type.getProperty('putMethod', 'PUT'), // allow user to override put method
+              url: url, 
+              data: this.$wrap(Utils.UPDATE_MASK) 
+            };
           }
 
           this
@@ -341,7 +347,12 @@ RMModule.factory('RMRecordApi', ['RMUtils', function(Utils) {
           url = this.$url('create') || this.$scope.$url();
           Utils.assert(!!url, 'Cant $create if parent scope is not bound');
 
-          request = { method: 'POST', url: url, data: this.$wrap(Utils.CREATE_MASK) };
+          request = { 
+            method: this.$type.getProperty('postMethod', 'POST'), // allow user to override post method
+            url: url, 
+            data: this.$wrap(Utils.CREATE_MASK) 
+          };
+
           this
             .$dispatch('before-save', [request])
             .$dispatch('before-create', [request])
@@ -370,7 +381,8 @@ RMModule.factory('RMRecordApi', ['RMUtils', function(Utils) {
      *
      * @description Begin a server request to destroy the resource.
      *
-     * The request's promise can be accessed using the `$asPromise` method.
+     * The request's promise can be accessed using the `$asPromise` method. It is posible to change
+     * the methods used for DELETE operations by setting the `deleteMethod` configuration.
      *
      * @return {RecordApi} this
      */
@@ -379,7 +391,10 @@ RMModule.factory('RMRecordApi', ['RMUtils', function(Utils) {
         var url = this.$url('destroy');
         if(url)
         {
-          var request = { method: 'DELETE', url: url };
+          var request = { 
+            method: this.$type.getProperty('deleteMethod', 'DELETE'), // allow user to override delete method 
+            url: url 
+          };
 
           this
             .$dispatch('before-destroy', [request])


### PR DESCRIPTION
I had to send different HTTP methods instead if PUT/POST/DELETE so I made it as configurable options in this branch. You can have a look at the changes if they are merge-able. I have updated doc blocks as well.