### PR TITLE
Enhancement: Cache array, object, gradual feeding

### DIFF
--- a/src/module/packer-cache.js
+++ b/src/module/packer-cache.js
@@ -35,11 +35,24 @@ RMModule.factory('RMPackerCache', [function() {
      * @param {string} _name Resource name (singular)
      * @param {array} _rawRecords Raw record data as an array
      */
-    feed: function(_name, _rawRecords) {
-      packerCache[_name] = _rawRecords; // TODO: maybe append new record to support extended scenarios.
-    },
+    feed: function(_name, _raw) {
 
-    // IDEA: feedSingle: would require two step resolve many -> single
+      var self = this;
+      if(!packerCache){ this.prepare(); }
+
+      if(angular.isArray(_raw)){
+        angular.forEach(_raw, function(_obj){
+          self.feed(_name, _obj);
+        });
+      }else if(angular.isObject(_raw)){
+        packerCache[_name] = packerCache[_name] || [];
+        packerCache[_name].unshift(_raw);
+      }else{
+        return false;
+      }
+
+      return true;
+    },
 
     /**
      * @memberof PackerCache#

--- a/test/packer-cache-spec.js
+++ b/test/packer-cache-spec.js
@@ -19,6 +19,76 @@ describe('RMPackerCache', function() {
     });
   }));
 
+  describe('feed', function() {
+
+    it('shouldnt fail if packer not initialized', function() {
+      expect(function() {
+        packerCache.feed("test", []);
+      }).not.toThrow();
+    });
+
+    it('should feed data if passed as array at start', function() {
+      packerCache.feed('bikes', [ { id: 1, model: 'Meta' }, { id: 2, model: 'Slash' } ]);
+      var bike = packerCache.resolve(Bike.$new(1));
+      expect(bike.model).toEqual('Meta');
+    });
+
+    it('should feed data if passed as object at start', function() {
+      packerCache.feed('bikes', { id: 3, model: 'Mango' });
+      var bike = packerCache.resolve(Bike.$new(3));
+      expect(bike.model).toEqual('Mango');
+    });
+
+    it('should feed array is passed after array', function() {
+      packerCache.feed('bikes', [ { id: 4, model: 'Apple' }, { id: 5, model: 'Mango' } ]);
+      packerCache.feed('bikes', [ { id: 6, model: 'Banana' }, { id: 7, model: 'Dates' } ]);
+      var bike = packerCache.resolve(Bike.$new(4)),
+          bike2 = packerCache.resolve(Bike.$new(6));
+      expect(bike.model).toEqual('Apple');
+      expect(bike2.model).toEqual('Banana');
+    });
+
+    it('should feed object is passed after array', function() {
+      packerCache.feed('bikes', [ { id: 8, model: 'Apple' }, { id: 9, model: 'Mango' } ]);
+      packerCache.feed('bikes', { id: 10, model: 'Banana' });
+      var bike = packerCache.resolve(Bike.$new(8)),
+          bike2 = packerCache.resolve(Bike.$new(10));
+      expect(bike.model).toEqual('Apple');
+      expect(bike2.model).toEqual('Banana');
+    });
+
+    it('should feed array is passed after object', function() {
+      packerCache.feed('bikes', { id: 11, model: 'Banana' });
+      packerCache.feed('bikes', [ { id: 12, model: 'Apple' }, { id: 13, model: 'Mango' } ]);
+      var bike = packerCache.resolve(Bike.$new(12)),
+          bike2 = packerCache.resolve(Bike.$new(11));
+      expect(bike.model).toEqual('Apple');
+      expect(bike2.model).toEqual('Banana');
+    });
+
+    it('should feed object is passed after object', function() {
+      packerCache.feed('bikes', { id: 14, model: 'Apple' });
+      packerCache.feed('bikes', { id: 15, model: 'Banana' });
+      var bike = packerCache.resolve(Bike.$new(14)),
+          bike2 = packerCache.resolve(Bike.$new(15));
+      expect(bike.model).toEqual('Apple');
+      expect(bike2.model).toEqual('Banana');
+    });
+
+    it('should resolve with latest object fed', function() {
+      packerCache.feed('bikes', { id: 16, model: 'Apple' });
+      packerCache.feed('bikes', { id: 16, model: 'Banana' });
+      var bike = packerCache.resolve(Bike.$new(16));
+      expect(bike.model).toEqual('Banana');
+    });
+
+    it('should return false if passed data is invalid', function() {
+      var ret = packerCache.feed('bikes', "Invalid");
+      expect(ret).toEqual(false);
+    });
+
+  });
+
   describe('restore', function() {
 
     it('shouldnt fail if packer not initialized', function() {


### PR DESCRIPTION
I am working on jsonapi.org strict standard and that is sending everything in included:{} element, which need object and gradual cache feeding. Please have a look and see if this can be mergable or suggest any improvements.